### PR TITLE
StackSampler: Disable ITIMER_VIRTUAL on exit

### DIFF
--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -1,0 +1,24 @@
+import time
+from stacksampler import Sampler
+
+
+def slp():
+    time.sleep(0.00001)
+
+
+def fn():
+    for i in range(50000):
+        slp()
+
+
+s = Sampler()
+
+
+def test_foo():
+    s.start()
+    fn()
+    print s.output_stats()
+
+
+if __name__ == '__main__':
+    test_foo()


### PR DESCRIPTION
The bug can be reproduced by runing `python tests/test_sampler.py`.

`signal.setitimer(signal.ITIMER_VIRTUAL, 0)` should be called before the process exits, otherwise a program using the sampler may exit with code 154.

```
# Before the PR
$ python tests/test_sampler.py
elapsed 0.941686153412
granularity 0.005
<module>(__main__);test_foo(__main__);fn(__main__);slp(__main__) 5

[1]    33765 virtual time alarm  python tests/test_sampler.py
$ echo $?           154 ↵
154

# After the PR
$ python tests/test_sampler.py
elapsed 0.953591108322
granularity 0.005
<module>(__main__);test_foo(__main__);fn(__main__);slp(__main__) 5

$ echo $?
0
```

ref: http://www.programcreek.com/python/example/57585/signal.ITIMER_VIRTUAL
